### PR TITLE
Add configuration to map Gitlab repos to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ If that configuration item is not set, no validation will be done. If it _is_
 set then it is required to be present and any hook that does not set the
 header will be given a `403 Forbidden` response.
 
+## Mapping GitLab repositories
+
+The connector operates by taking advantage of the existing GitHub to CircleCI
+integration. Thus it requires you to setup a GitHub project and configure the
+GitLab to GitHub mapping in the configuration.
+
+For example, for the GitLab project with ID 1000, map it to the `myorg/myrepo`
+GitHub repository:
+
+```yaml
+domainMapping:
+  repositories:
+    1000: gh/myorg/myrepo
+```
+
 ## Logging
 
 By default, this service will log to standard output. To configure it further,

--- a/src/main/java/com/circleci/connector/gitlab/singleorg/ConnectorConfiguration.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/ConnectorConfiguration.java
@@ -2,7 +2,10 @@ package com.circleci.connector.gitlab.singleorg;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import java.util.Map;
+import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.Range;
 
 public class ConnectorConfiguration extends Configuration {
@@ -11,6 +14,8 @@ public class ConnectorConfiguration extends Configuration {
   private GitLab gitlab;
 
   private Statsd statsd;
+
+  @Valid private DomainMapping domainMapping;
 
   public ConnectorConfiguration() {}
 
@@ -45,6 +50,17 @@ public class ConnectorConfiguration extends Configuration {
 
   void setStatsd(Statsd s) {
     statsd = s;
+  }
+
+  public DomainMapping getDomainMapping() {
+    if (domainMapping == null) {
+      return new DomainMapping();
+    }
+    return domainMapping;
+  }
+
+  public void setDomainMapping(DomainMapping domainMapping) {
+    this.domainMapping = domainMapping;
   }
 
   static class CircleCi {
@@ -142,6 +158,23 @@ public class ConnectorConfiguration extends Configuration {
     @JsonProperty
     void setRefreshPeriodSeconds(int seconds) {
       refreshPeriodSeconds = seconds;
+    }
+  }
+
+  static class DomainMapping {
+    private Map<@Range(min = 0) Integer, @Pattern(regexp = "[^/]+/[^/]+/[^/]+") String>
+        repositories;
+
+    public Map<Integer, String> getRepositories() {
+      return repositories;
+    }
+
+    /**
+     * @param repositories A map of GitLab repository ids to CircleCI repository paths, like
+     *     "gh/org/repo"
+     */
+    public void setRepositories(Map<Integer, String> repositories) {
+      this.repositories = repositories;
     }
   }
 }

--- a/src/test/java/com/circleci/connector/gitlab/singleorg/ConnectorConfigurationTest.java
+++ b/src/test/java/com/circleci/connector/gitlab/singleorg/ConnectorConfigurationTest.java
@@ -8,6 +8,7 @@ import io.dropwizard.configuration.YamlConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.util.Resources;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class ConnectorConfigurationTest {
@@ -17,6 +18,7 @@ class ConnectorConfigurationTest {
     assertNotNull(cfg.getCircleCi());
     assertNotNull(cfg.getGitlab());
     assertNotNull(cfg.getStatsd());
+    assertNotNull(cfg.getDomainMapping());
   }
 
   @Test
@@ -24,6 +26,7 @@ class ConnectorConfigurationTest {
     ConnectorConfiguration cfg = loadFromResources("complete-config.yml");
     assertEquals("super-secret", cfg.getGitlab().getSharedSecretForHooks());
     assertNotNull("not-really-a-token", cfg.getCircleCi().getApiToken());
+    assertEquals(Map.of(123, "gh/ghorg/ghrepo"), cfg.getDomainMapping().getRepositories());
   }
 
   @Test

--- a/src/test/resources/complete-config.yml
+++ b/src/test/resources/complete-config.yml
@@ -8,3 +8,6 @@ statsd:
   host: "localhost"
   port: 123
   refreshPeriodSeconds: 3
+domainMapping:
+  repositories:
+    123: gh/ghorg/ghrepo


### PR DESCRIPTION
Note: `@Valid` seems to be necessary to "propagate" the validation from the Configuration to the composing objects. We should add it to the other objects (in a separate PR)