### PR TITLE
[CIRCLE-20643] Trigger pipelines for push hooks

### DIFF
--- a/src/main/java/com/circleci/connector/gitlab/singleorg/ConnectorApplication.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/ConnectorApplication.java
@@ -75,9 +75,7 @@ class ConnectorApplication extends Application<ConnectorConfiguration> {
 
     environment.healthChecks().register("CircleCI API", new CircleCiApiHealthCheck(circleCiApi));
     environment.healthChecks().register("GitLab API", new GitLabApiHealthCheck(gitLabApi));
-    environment
-        .jersey()
-        .register(new HookResource(gitLab, config.getGitlab().getSharedSecretForHooks()));
+    environment.jersey().register(new HookResource(gitLab, circleCiApi, config));
 
     maybeConfigureStatsdMetrics(config, environment.metrics());
   }

--- a/src/main/java/com/circleci/connector/gitlab/singleorg/ConnectorConfiguration.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/ConnectorConfiguration.java
@@ -2,6 +2,7 @@ package com.circleci.connector.gitlab.singleorg;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.Configuration;
+import java.util.HashMap;
 import java.util.Map;
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
@@ -30,7 +31,7 @@ public class ConnectorConfiguration extends Configuration {
     circleCi = cci;
   }
 
-  GitLab getGitlab() {
+  public GitLab getGitlab() {
     if (gitlab == null) {
       return new GitLab();
     }
@@ -79,7 +80,7 @@ public class ConnectorConfiguration extends Configuration {
     }
   }
 
-  static class GitLab {
+  public static class GitLab {
     private String sharedSecretForHooks;
 
     private String host = "https://gitlab.com";
@@ -89,7 +90,7 @@ public class ConnectorConfiguration extends Configuration {
     GitLab() {}
 
     @JsonProperty
-    String getSharedSecretForHooks() {
+    public String getSharedSecretForHooks() {
       return sharedSecretForHooks;
     }
 
@@ -161,11 +162,14 @@ public class ConnectorConfiguration extends Configuration {
     }
   }
 
-  static class DomainMapping {
+  public static class DomainMapping {
     private Map<@Range(min = 0) Integer, @Pattern(regexp = "[^/]+/[^/]+/[^/]+") String>
         repositories;
 
     public Map<Integer, String> getRepositories() {
+      if (repositories == null) {
+        return new HashMap<>();
+      }
       return repositories;
     }
 

--- a/src/main/java/com/circleci/connector/gitlab/singleorg/api/HookResponse.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/api/HookResponse.java
@@ -1,8 +1,10 @@
 package com.circleci.connector.gitlab.singleorg.api;
 
+import com.circleci.client.v2.model.PipelineLight;
 import com.circleci.connector.gitlab.singleorg.resources.HookResource;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import org.immutables.value.Value;
 
 /** For responses to the /hooks/* endpoints as implemented by {@link HookResource}. */
@@ -18,4 +20,8 @@ public abstract class HookResponse {
 
   @JsonProperty
   public abstract Status status();
+
+  @JsonProperty
+  @Nullable
+  public abstract PipelineLight pipeline();
 }

--- a/src/main/java/com/circleci/connector/gitlab/singleorg/api/PushHook.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/api/PushHook.java
@@ -24,6 +24,15 @@ public abstract class PushHook {
     return UUID.randomUUID();
   };
 
+  @Value.Derived
+  @JsonIgnore
+  public String branch() {
+    if (ref() != null && ref().startsWith("refs/heads/")) {
+      return ref().substring(11);
+    }
+    return null;
+  }
+
   @JsonProperty("object_kind")
   @NotEmpty
   abstract ObjectKind objectKind();

--- a/src/main/resources/default-container-config.yml
+++ b/src/main/resources/default-container-config.yml
@@ -1,5 +1,7 @@
 ---
 
+circleCi:
+  apiToken: ${CIRCLECI_API_TOKEN:-set this to your token value}
 server:
   applicationConnectors:
     - type: http

--- a/src/test/java/com/circleci/connector/gitlab/singleorg/api/HookResponseTest.java
+++ b/src/test/java/com/circleci/connector/gitlab/singleorg/api/HookResponseTest.java
@@ -19,7 +19,11 @@ class HookResponseTest {
     assertEquals(id, hr.id());
     assertEquals(HookResponse.Status.SUBMITTED, hr.status());
     assertEquals(
-        "{\"id\":\"ae45d0e4-763a-493e-a655-76ce1195320a\",\"status\":\"SUBMITTED\"}",
+        "{"
+            + "\"id\":\"ae45d0e4-763a-493e-a655-76ce1195320a\","
+            + "\"status\":\"SUBMITTED\","
+            + "\"pipeline\":null"
+            + "}",
         MAPPER.writeValueAsString(hr));
   }
 }


### PR DESCRIPTION
On receipt of a hook from Gitlab, use the CircleCI API to trigger a new pipeline with the same details as the hook provides.