### PR TITLE
Pull correct branch when using git-checkout command

### DIFF
--- a/src/main/java/com/circleci/connector/gitlab/singleorg/client/GitLab.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/client/GitLab.java
@@ -32,7 +32,8 @@ public class GitLab {
           + "  - run: |\n"
           + "      mkdir -p ~/.ssh\n"
           + "      ssh-keyscan gitlab.com >> ~/.ssh/known_hosts\n"
-          + "      git clone --depth=1 << pipeline.parameters.gitlab_git_uri >> project";
+          + "      git clone --single-branch --branch $CIRCLE_BRANCH "
+          + "        --depth=1 << pipeline.parameters.gitlab_git_uri >> project";
 
   private static final JsonNode STRING_PARAMETER_NODE;
   private static final JsonNode GIT_CHECKOUT_COMMAND_NODE;

--- a/src/test/resources/circleci-config/empty.output.yaml
+++ b/src/test/resources/circleci-config/empty.output.yaml
@@ -12,4 +12,4 @@ commands:
           fingerprints:
             - "<< pipeline.parameters.gitlab_ssh_fingerprint >>"
       - run: "mkdir -p ~/.ssh\nssh-keyscan gitlab.com >> ~/.ssh/known_hosts\ngit clone\
-        \ --depth=1 << pipeline.parameters.gitlab_git_uri >> project"
+        \ --single-branch --branch $CIRCLE_BRANCH         --depth=1 << pipeline.parameters.gitlab_git_uri >> project"

--- a/src/test/resources/circleci-config/valid-commands.output.yaml
+++ b/src/test/resources/circleci-config/valid-commands.output.yaml
@@ -20,7 +20,7 @@ commands:
           fingerprints:
             - "<< pipeline.parameters.gitlab_ssh_fingerprint >>"
       - run: "mkdir -p ~/.ssh\nssh-keyscan gitlab.com >> ~/.ssh/known_hosts\ngit clone\
-        \ --depth=1 << pipeline.parameters.gitlab_git_uri >> project"
+        \ --single-branch --branch $CIRCLE_BRANCH         --depth=1 << pipeline.parameters.gitlab_git_uri >> project"
   my-command:
     steps:
       - run: true

--- a/src/test/resources/circleci-config/valid-parameters.output.yaml
+++ b/src/test/resources/circleci-config/valid-parameters.output.yaml
@@ -23,4 +23,4 @@ commands:
           fingerprints:
             - "<< pipeline.parameters.gitlab_ssh_fingerprint >>"
       - run: "mkdir -p ~/.ssh\nssh-keyscan gitlab.com >> ~/.ssh/known_hosts\ngit clone\
-        \ --depth=1 << pipeline.parameters.gitlab_git_uri >> project"
+        \ --single-branch --branch $CIRCLE_BRANCH         --depth=1 << pipeline.parameters.gitlab_git_uri >> project"

--- a/src/test/resources/circleci-config/valid-simple.output.yaml
+++ b/src/test/resources/circleci-config/valid-simple.output.yaml
@@ -20,4 +20,4 @@ commands:
           fingerprints:
             - "<< pipeline.parameters.gitlab_ssh_fingerprint >>"
       - run: "mkdir -p ~/.ssh\nssh-keyscan gitlab.com >> ~/.ssh/known_hosts\ngit clone\
-        \ --depth=1 << pipeline.parameters.gitlab_git_uri >> project"
+        \ --single-branch --branch $CIRCLE_BRANCH         --depth=1 << pipeline.parameters.gitlab_git_uri >> project"


### PR DESCRIPTION
There is a risk of the head of the branch pointing to something else by the time we pull it. Not sure how to mitigate that.