### PR TITLE
[CIRCLE-21791] Add support for delayed background jobs.

### DIFF
--- a/src/main/java/com/circleci/connector/gitlab/singleorg/ConnectorApplication.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/ConnectorApplication.java
@@ -77,9 +77,13 @@ class ConnectorApplication extends Application<ConnectorConfiguration> {
     GitLabApi gitLabApi = gitLabApi(config);
     GitLab gitLab = new GitLab(gitLabApi);
 
+    var scheduledJobRunner =
+        environment.lifecycle().scheduledExecutorService("scheduled-job-%d", true).build();
     environment.healthChecks().register("CircleCI API", new CircleCiApiHealthCheck(circleCiApi));
     environment.healthChecks().register("GitLab API", new GitLabApiHealthCheck(gitLabApi));
-    environment.jersey().register(new HookResource(gitLab, circleCiApi, config));
+    environment
+        .jersey()
+        .register(new HookResource(gitLab, circleCiApi, scheduledJobRunner, config));
 
     maybeConfigureStatsdMetrics(config, environment.metrics());
   }

--- a/src/main/java/com/circleci/connector/gitlab/singleorg/resources/HookResource.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/resources/HookResource.java
@@ -17,6 +17,7 @@ import io.dropwizard.jackson.Jackson;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.BadRequestException;
@@ -50,14 +51,21 @@ public class HookResource {
   /** The configuration for this service. */
   @NotNull private final ConnectorConfiguration config;
 
+  @NotNull private final ScheduledExecutorService scheduledJobRunner;
+
   /**
    * @param gitLabClient A configured GitLab API client.
    * @param circleCiApi The CircleCI API library, configured to call the CircleCI REST API.
    * @param config The configuration for this service.
    */
-  public HookResource(GitLab gitLabClient, DefaultApi circleCiApi, ConnectorConfiguration config) {
+  public HookResource(
+      GitLab gitLabClient,
+      DefaultApi circleCiApi,
+      ScheduledExecutorService scheduledJobRunner,
+      ConnectorConfiguration config) {
     this.gitLabClient = gitLabClient;
     this.circleCiApi = circleCiApi;
+    this.scheduledJobRunner = scheduledJobRunner;
     this.config = config;
   }
 

--- a/src/test/java/com/circleci/connector/gitlab/singleorg/ConnectorApplicationTest.java
+++ b/src/test/java/com/circleci/connector/gitlab/singleorg/ConnectorApplicationTest.java
@@ -11,6 +11,7 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.jackson.Jackson;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,7 @@ class ConnectorApplicationTest {
   void setup() {
     when(environment.jersey()).thenReturn(jersey);
     when(environment.healthChecks()).thenReturn(healthCheckRegistry);
+    when(environment.lifecycle()).thenReturn(new LifecycleEnvironment(metricRegistry));
   }
 
   @Test


### PR DESCRIPTION
Allow HTTP handlers to hand off work to a background thread.