### PR TITLE
[CIRCLE-21792] Poll the CircleCI API for pipeline status updates

### DIFF
--- a/src/main/java/com/circleci/connector/gitlab/singleorg/client/PipelineStatusPoller.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/client/PipelineStatusPoller.java
@@ -1,0 +1,174 @@
+package com.circleci.connector.gitlab.singleorg.client;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import com.circleci.client.v2.ApiException;
+import com.circleci.client.v2.api.DefaultApi;
+import com.circleci.client.v2.model.PipelineLight;
+import com.circleci.client.v2.model.PipelineWithWorkflows;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.Nullable;
+import org.gitlab4j.api.Constants.CommitBuildState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PipelineStatusPoller {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PipelineStatusPoller.class);
+
+  /** The amount to delay before polling the CircleCI API for the first time. */
+  private static final long INITIAL_DELAY_MILLIS = 1000;
+
+  /** The GitLab ID for the GitLab project we're updating. */
+  private final int projectId;
+
+  /** The pipeline we're polling for status. */
+  private final PipelineLight pipeline;
+
+  /** The CircleCI client for calling the CircleCI API. */
+  private final DefaultApi circleCi;
+
+  /** The GitLab client for calling the the GitLab API. */
+  private final GitLab gitLab;
+
+  /** State to manage the sleep and retry policy of this poller instance. */
+  private final RetryPolicy retryPolicy;
+
+  /** We get passed a reference to this in order to allow us to re-schedule a job to run later. */
+  private final ScheduledExecutorService jobRunner;
+
+  public PipelineStatusPoller(
+      int projectId,
+      PipelineLight pipeline,
+      DefaultApi circleCi,
+      GitLab gitLab,
+      ScheduledExecutorService jobRunner) {
+    this.projectId = projectId;
+    this.pipeline = pipeline;
+    this.circleCi = circleCi;
+    this.gitLab = gitLab;
+    this.jobRunner = jobRunner;
+    retryPolicy = new RetryPolicy();
+  }
+
+  /** Start polling the CircleCI API and continue polling until we get to a terminal state. */
+  public void start() {
+    schedule(INITIAL_DELAY_MILLIS);
+  }
+
+  /**
+   * Poll the CircleCI API and update GitLab with the status.
+   *
+   * @return The number of milliseconds to delay before polling again, or a negative number if we
+   *     wish to stop polling.
+   */
+  @VisibleForTesting
+  long poll() {
+    LOGGER.info("Polling for the status of CircleCI pipeline {}", pipeline.getId());
+    PipelineWithWorkflows p;
+    try {
+      p = circleCi.getPipelineById(pipeline.getId());
+    } catch (ApiException e) {
+      LOGGER.error(
+          "Caught error while polling for the status of CircleCI pipeline {}", pipeline.getId(), e);
+      return retryPolicy.delayFor(null);
+    }
+
+    return retryPolicy.delayFor(gitLab.updateCommitStatus(projectId, p));
+  }
+
+  /**
+   * Schedule the polling on the jobRunner.
+   *
+   * @param delayMillis The number of milliseconds to delay before running the job once.
+   */
+  private void schedule(long delayMillis) {
+    LOGGER.info(
+        "Scheduling a poll of CircleCI pipeline {} in {}ms from now",
+        pipeline.getId(),
+        delayMillis);
+    jobRunner.schedule(
+        () -> {
+          long rescheduleAfter = poll();
+          if (rescheduleAfter >= 0) {
+            schedule(rescheduleAfter);
+          }
+        },
+        delayMillis,
+        MILLISECONDS);
+  }
+
+  /** Parcel up the retry delays and policy in a single, testable place. */
+  static class RetryPolicy {
+    private long consecutiveErrors;
+
+    @Nullable private CommitBuildState lastState;
+
+    private long lastDelay;
+
+    private static final long MAX_CONSECUTIVE_ERRORS = 10;
+
+    private static final long MAX_SLEEP_INTERVAL_MS = 10000;
+
+    private static final long INITIAL_SLEEP_MS = 100;
+
+    RetryPolicy() {
+      consecutiveErrors = 0;
+      lastState = null;
+      lastDelay = INITIAL_SLEEP_MS;
+    }
+
+    /**
+     * Sleep longer than the previous sleep. Back off exponentially, but cap at
+     * MAX_SLEEP_INTERVAL_MS.
+     *
+     * @return The number of milliseconds to sleep before the next poll.
+     */
+    long sleepLonger() {
+      lastDelay *= 2;
+      if (lastDelay > MAX_SLEEP_INTERVAL_MS) {
+        lastDelay = MAX_SLEEP_INTERVAL_MS;
+      }
+      return lastDelay;
+    }
+
+    /**
+     * Compute the delay until the next poll.
+     *
+     * @param gitLabState The state we set on GitLab. Null if there was an error.
+     * @return The number of milliseconds we should sleep for or a negative number if we should stop
+     *     polling.
+     */
+    long delayFor(CommitBuildState gitLabState) {
+      // If there was an error we want to retry
+      if (gitLabState == null) {
+        consecutiveErrors++;
+        if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+          return -1; // Give up due to too many errors
+        }
+        return sleepLonger();
+      }
+
+      // If we get this far, there was no error so reset the consecutive error count.
+      consecutiveErrors = 0;
+
+      switch (gitLabState) {
+        case CANCELED:
+        case FAILED:
+        case SUCCESS:
+          return -1; // Terminal state, stop polling
+        case PENDING:
+        case RUNNING:
+          if (gitLabState.equals(lastState)) {
+            return sleepLonger();
+          }
+          lastState = gitLabState;
+          lastDelay = 1000;
+          return lastDelay;
+        default:
+          throw new IllegalArgumentException(
+              String.format("Unknown GitLab state: %s", gitLabState));
+      }
+    }
+  }
+}

--- a/src/main/java/com/circleci/connector/gitlab/singleorg/resources/HookResource.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/resources/HookResource.java
@@ -10,6 +10,7 @@ import com.circleci.connector.gitlab.singleorg.api.ImmutableHookResponse;
 import com.circleci.connector.gitlab.singleorg.api.ImmutablePushHook;
 import com.circleci.connector.gitlab.singleorg.api.PushHook;
 import com.circleci.connector.gitlab.singleorg.client.GitLab;
+import com.circleci.connector.gitlab.singleorg.client.PipelineStatusPoller;
 import com.codahale.metrics.annotation.Timed;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -142,6 +143,10 @@ public class HookResource {
       }
       throw e;
     }
+
+    // Poll the CircleCI API for status updates to the pipeline and update GitLab appropriately
+    (new PipelineStatusPoller(projectId, pipeline, circleCiApi, gitLabClient, scheduledJobRunner))
+        .start();
 
     return responseBuilder.status(HookResponse.Status.SUBMITTED).pipeline(pipeline).build();
   }

--- a/src/test/java/com/circleci/connector/gitlab/singleorg/client/PipelineStatusPollerTest.java
+++ b/src/test/java/com/circleci/connector/gitlab/singleorg/client/PipelineStatusPollerTest.java
@@ -1,0 +1,103 @@
+package com.circleci.connector.gitlab.singleorg.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.circleci.client.v2.ApiException;
+import com.circleci.client.v2.api.DefaultApi;
+import com.circleci.client.v2.model.PipelineLight;
+import com.circleci.client.v2.model.PipelineWithWorkflows;
+import com.circleci.client.v2.model.PipelineWithWorkflowsVcs;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
+import org.gitlab4j.api.Constants.CommitBuildState;
+import org.junit.jupiter.api.Test;
+
+class PipelineStatusPollerTest {
+  private static final DefaultApi CIRCLECI = mock(DefaultApi.class);
+  private static final GitLab GITLAB = mock(GitLab.class);
+  private static final ScheduledExecutorService JOB_RUNNER = mock(ScheduledExecutorService.class);
+
+  @Test
+  void pollSleepsWhenTheCircleCiApiCallFails() throws ApiException {
+    UUID pipelineId = UUID.randomUUID();
+    int projectId = 123456;
+    PipelineLight pipeline = (new PipelineLight()).id(pipelineId);
+
+    when(CIRCLECI.getPipelineById(pipelineId)).thenThrow(new ApiException());
+    PipelineStatusPoller poller =
+        new PipelineStatusPoller(projectId, pipeline, CIRCLECI, GITLAB, JOB_RUNNER);
+    assertTrue(poller.poll() > 0);
+  }
+
+  @Test
+  void pollSleepsWhenThePipelineIsRunning() throws ApiException {
+    UUID pipelineId = UUID.randomUUID();
+    int projectId = 123456;
+    String sha1 = "8e38b1205365ed98c8f27ed2e1f35166a3f5858f";
+    PipelineLight pipeline = (new PipelineLight()).id(pipelineId);
+    PipelineWithWorkflows p =
+        (new PipelineWithWorkflows())
+            .id(pipelineId)
+            .state(PipelineWithWorkflows.StateEnum.RUNNING)
+            .vcs(new PipelineWithWorkflowsVcs().revision(sha1));
+
+    when(CIRCLECI.getPipelineById(pipelineId)).thenReturn(p);
+    when(GITLAB.updateCommitStatus(projectId, p)).thenReturn(CommitBuildState.RUNNING);
+    PipelineStatusPoller poller =
+        new PipelineStatusPoller(projectId, pipeline, CIRCLECI, GITLAB, JOB_RUNNER);
+    assertTrue(poller.poll() > 0);
+  }
+
+  @Test
+  void retryPolicyCoversAllGitLabStatuses() {
+    for (var state : CommitBuildState.values()) {
+      var policy = new PipelineStatusPoller.RetryPolicy();
+      long delay = policy.delayFor(state);
+      assertTrue(delay >= -1);
+    }
+  }
+
+  @Test
+  void retryPolicyDoesNotBackOffAsStatesTransition() {
+    var policy = new PipelineStatusPoller.RetryPolicy();
+    assertEquals(1000, policy.delayFor(CommitBuildState.PENDING));
+    assertEquals(1000, policy.delayFor(CommitBuildState.RUNNING));
+    assertEquals(-1, policy.delayFor(CommitBuildState.SUCCESS));
+  }
+
+  @Test
+  void retryPolicyBacksOffForRepeatedIdenticalStatuses() {
+    var policy = new PipelineStatusPoller.RetryPolicy();
+    assertEquals(1000, policy.delayFor(CommitBuildState.PENDING));
+    assertEquals(2000, policy.delayFor(CommitBuildState.PENDING));
+    assertEquals(4000, policy.delayFor(CommitBuildState.PENDING));
+    assertEquals(8000, policy.delayFor(CommitBuildState.PENDING));
+    assertEquals(10000, policy.delayFor(CommitBuildState.PENDING));
+    assertEquals(10000, policy.delayFor(CommitBuildState.PENDING));
+    assertEquals(1000, policy.delayFor(CommitBuildState.RUNNING));
+    assertEquals(2000, policy.delayFor(CommitBuildState.RUNNING));
+    assertEquals(4000, policy.delayFor(CommitBuildState.RUNNING));
+    assertEquals(8000, policy.delayFor(CommitBuildState.RUNNING));
+    assertEquals(10000, policy.delayFor(CommitBuildState.RUNNING));
+    assertEquals(10000, policy.delayFor(CommitBuildState.RUNNING));
+    assertEquals(-1, policy.delayFor(CommitBuildState.SUCCESS));
+  }
+
+  @Test
+  void retryPolicyGivesUpAfterEnoughConsecutiveErrors() {
+    var policy = new PipelineStatusPoller.RetryPolicy();
+    assertEquals(200, policy.delayFor(null));
+    assertEquals(400, policy.delayFor(null));
+    assertEquals(800, policy.delayFor(null));
+    assertEquals(1600, policy.delayFor(null));
+    assertEquals(3200, policy.delayFor(null));
+    assertEquals(6400, policy.delayFor(null));
+    assertEquals(10000, policy.delayFor(null));
+    assertEquals(10000, policy.delayFor(null));
+    assertEquals(10000, policy.delayFor(null));
+    assertEquals(-1, policy.delayFor(null));
+  }
+}


### PR DESCRIPTION
After triggering a pipeline, poll its status so that we can update the relevant commit on GitLab.