### PR TITLE
Pass atribution data when triggering pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
     <dependency>
       <groupId>com.circleci</groupId>
       <artifactId>java-client</artifactId>
-      <version>2.0.94</version>
+      <version>2.0.114</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/com/circleci/connector/gitlab/singleorg/api/PushHook.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/api/PushHook.java
@@ -22,7 +22,7 @@ public abstract class PushHook {
   @JsonIgnore
   public UUID id() {
     return UUID.randomUUID();
-  };
+  }
 
   @Value.Derived
   @JsonIgnore
@@ -48,7 +48,7 @@ public abstract class PushHook {
 
   @JsonProperty("user_id")
   @Range(min = 0)
-  abstract int userId();
+  public abstract int userId();
 
   @JsonProperty("user_name")
   @NotEmpty
@@ -57,6 +57,10 @@ public abstract class PushHook {
   @JsonProperty("user_username")
   @NotEmpty
   abstract String userUsername();
+
+  @JsonProperty("user_email")
+  @NotEmpty
+  public abstract String userEmail();
 
   @NotNull
   public abstract Project project();

--- a/src/main/java/com/circleci/connector/gitlab/singleorg/client/CircleCi.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/client/CircleCi.java
@@ -121,6 +121,8 @@ public class CircleCi {
   public Pipeline triggerPipeline(
       Pipeline pipeline,
       String circleCiConfig,
+      String userId,
+      String login,
       String projectSlug,
       String sshFingerprint,
       String gitSshUrl) {
@@ -134,7 +136,7 @@ public class CircleCi {
       params.setRevision(pipeline.revision());
       params.setParameters(
           Map.of("gitlab_ssh_fingerprint", sshFingerprint, "gitlab_git_uri", gitSshUrl));
-      PipelineLight pipelineLight = circleCiApi.triggerPipeline(projectSlug, params);
+      PipelineLight pipelineLight = circleCiApi.triggerPipeline(projectSlug, login, userId, params);
       return ImmutablePipeline.builder().from(pipeline).id(pipelineLight.getId()).build();
     } catch (ApiException e) {
       LOGGER.error("Failed to trigger pipeline", e);

--- a/src/main/java/com/circleci/connector/gitlab/singleorg/resources/HookResource.java
+++ b/src/main/java/com/circleci/connector/gitlab/singleorg/resources/HookResource.java
@@ -118,6 +118,8 @@ public class HookResource {
         circleCiClient.triggerPipeline(
             pipeline,
             circleCiConfig.get(),
+            Integer.toString(hook.userId()),
+            hook.userEmail(),
             projectSlug,
             sshFingerprint,
             hook.project().gitSshUrl());

--- a/src/test/java/com/circleci/connector/gitlab/singleorg/api/PushHookTest.java
+++ b/src/test/java/com/circleci/connector/gitlab/singleorg/api/PushHookTest.java
@@ -23,6 +23,7 @@ class PushHookTest {
     assertEquals(4, hook.userId());
     assertEquals("John Smith", hook.userName());
     assertEquals("jsmith", hook.userUsername());
+    assertEquals("john@example.com", hook.userEmail());
     assertEquals(15, hook.project().id());
     assertEquals("Diaspora", hook.project().name());
     assertEquals("git@example.com:mike/diaspora.git", hook.project().gitSshUrl());

--- a/src/test/java/com/circleci/connector/gitlab/singleorg/client/CircleCiTest.java
+++ b/src/test/java/com/circleci/connector/gitlab/singleorg/client/CircleCiTest.java
@@ -81,26 +81,30 @@ class CircleCiTest {
     CIRCLECI_WORKFLOW.setStatus(StatusEnum.RUNNING);
 
     try {
-      when(CIRCLECI_HAPPY.triggerPipeline(anyString(), any(TriggerPipelineParameters.class)))
+      when(CIRCLECI_HAPPY.triggerPipeline(
+              anyString(), anyString(), anyString(), any(TriggerPipelineParameters.class)))
           .thenReturn(PIPELINE_LIGHT);
       when(CIRCLECI_HAPPY.getPipelineById(PIPELINE_ID)).thenReturn(PIPELINE_WITH_WORKFLOWS);
       when(CIRCLECI_HAPPY.getWorkflowById(WORKFLOW_ID)).thenReturn(CIRCLECI_WORKFLOW);
 
-      when(CIRCLECI_404.triggerPipeline(anyString(), any(TriggerPipelineParameters.class)))
+      when(CIRCLECI_404.triggerPipeline(
+              anyString(), anyString(), anyString(), any(TriggerPipelineParameters.class)))
           .thenThrow(new ApiException(404, "No such project"));
       when(CIRCLECI_404.getPipelineById(any(UUID.class)))
           .thenThrow(new ApiException(404, "No such pipeline"));
       when(CIRCLECI_404.getWorkflowById(any(UUID.class)))
           .thenThrow(new ApiException(404, "No such workflow"));
 
-      when(CIRCLECI_404_JSON.triggerPipeline(anyString(), any(TriggerPipelineParameters.class)))
+      when(CIRCLECI_404_JSON.triggerPipeline(
+              anyString(), anyString(), anyString(), any(TriggerPipelineParameters.class)))
           .thenThrow(new ApiException(404, "{\"message\":\"No such project\"}"));
       when(CIRCLECI_404_JSON.getPipelineById(any(UUID.class)))
           .thenThrow(new ApiException(404, "{\"message\":\"No such pipeline\"}"));
       when(CIRCLECI_404_JSON.getWorkflowById(any(UUID.class)))
           .thenThrow(new ApiException(404, "{\"message\":\"No such workflow\"}"));
 
-      when(CIRCLECI_500.triggerPipeline(anyString(), any(TriggerPipelineParameters.class)))
+      when(CIRCLECI_500.triggerPipeline(
+              anyString(), anyString(), anyString(), any(TriggerPipelineParameters.class)))
           .thenThrow(new ApiException(500, "CircleCI is broken"));
       when(CIRCLECI_500.getPipelineById(any(UUID.class)))
           .thenThrow(new ApiException(500, "CircleCI is broken"));
@@ -176,7 +180,7 @@ class CircleCiTest {
     CircleCi circleCi = new CircleCi(CIRCLECI_404);
     assertThrows(
         ClientErrorException.class,
-        () -> circleCi.triggerPipeline(PIPELINE_WITHOUT_ID, "", "", "", ""));
+        () -> circleCi.triggerPipeline(PIPELINE_WITHOUT_ID, "", "", "", "", "", ""));
   }
 
   @Test
@@ -184,7 +188,7 @@ class CircleCiTest {
     CircleCi circleCi = new CircleCi(CIRCLECI_404_JSON);
     assertThrows(
         ClientErrorException.class,
-        () -> circleCi.triggerPipeline(PIPELINE_WITHOUT_ID, "", "", "", ""));
+        () -> circleCi.triggerPipeline(PIPELINE_WITHOUT_ID, "", "", "", "", "", ""));
   }
 
   @Test
@@ -192,7 +196,7 @@ class CircleCiTest {
     CircleCi circleCi = new CircleCi(CIRCLECI_500);
     assertThrows(
         RuntimeException.class,
-        () -> circleCi.triggerPipeline(PIPELINE_WITHOUT_ID, "", "", "", ""));
+        () -> circleCi.triggerPipeline(PIPELINE_WITHOUT_ID, "", "", "", "", "", ""));
   }
 
   @Test
@@ -200,13 +204,14 @@ class CircleCiTest {
     CircleCi circleCi = new CircleCi(CIRCLECI_HAPPY);
 
     assertThrows(
-        RuntimeException.class, () -> circleCi.triggerPipeline(PIPELINE_WITH_ID, "", "", "", ""));
+        RuntimeException.class,
+        () -> circleCi.triggerPipeline(PIPELINE_WITH_ID, "", "", "", "", "", ""));
   }
 
   @Test
   void triggerPipelineIfCircleCiReturnsPipelineSuccess() {
     CircleCi circleCi = new CircleCi(CIRCLECI_HAPPY);
-    Pipeline pipeline = circleCi.triggerPipeline(PIPELINE_WITHOUT_ID, "", "", "", "");
+    Pipeline pipeline = circleCi.triggerPipeline(PIPELINE_WITHOUT_ID, "", "", "", "", "", "");
     assertNotNull(pipeline);
     assertEquals(PIPELINE_LIGHT.getId(), pipeline.id());
   }


### PR DESCRIPTION
* [x] read email and user id from hook
* [x] update CircleCI client
* [x] pass email and id to `CircleCi::triggerPipeline` and set corresponding parameters

NB in `HookResourceTest`, mock creation was moved into a `@BeforeEach` method to reset the call counter on `CIRCLECI_HAPPY.triggerPipeline` and make it possible to _verify_ correct number of invocations.